### PR TITLE
Adds support for Pest v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3 || ^8.0 || ^8.1",
-        "pestphp/pest": "^1.5",
-        "pestphp/pest-plugin": "^1.0"
+        "php": "^8.1 || ^8.2",
+        "pestphp/pest": "^2.0",
+        "pestphp/pest-plugin": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,28 +30,31 @@
         }
     },
     "require-dev": {
+        "archtechx/money": "^0.5.0",
         "brick/money": "^0.5.3",
         "friendsofphp/php-cs-fixer": "^3.3",
         "moneyphp/money": "^3.3",
-        "orchestra/testbench": "^6.23",
-        "pestphp/pest-dev-tools": "dev-master",
+        "orchestra/testbench": "^8.0",
+        "pestphp/pest-dev-tools": "^2.0",
         "phpstan/phpstan": "^1.1"
     },
     "suggest": {
         "brick/money": "A powerful, immutable money library with support for specialized currencies",
-        "moneyphp/money": "A simpler but less versatile money library",
-        "archtechx/money": "A Laravel library for handling money"
+        "moneyphp/money": "A simpler but less versatile money library"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "scripts": {
         "lint": "./vendor/bin/php-cs-fixer fix -v",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix=".php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix=".php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/Contracts/ChecksMoney.php
+++ b/src/Contracts/ChecksMoney.php
@@ -8,6 +8,7 @@ use Pest\Expectation;
 
 /**
  * @template TMoney
+ *
  * @phpstan-type MoneyAmount TMoney|string|int|float
  */
 interface ChecksMoney

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lukeraymonddowning\PestPluginMoney;
 
-use InvalidArgumentException;
 use Lukeraymonddowning\PestPluginMoney\Contracts\ChecksMoney;
 
 /**
@@ -36,6 +35,6 @@ final class MoneyFactory
             return new Archtech();
         }
 
-        throw new InvalidArgumentException('You don\'t have a supported Money library installed!');
+        throw new \InvalidArgumentException('You don\'t have a supported Money library installed!');
     }
 }

--- a/tests/Archtech/toBeMoney.php
+++ b/tests/Archtech/toBeMoney.php
@@ -1,6 +1,7 @@
 <?php
 
 use ArchTech\Money\Money;
+
 use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 
 it('can determine correct money types for archtech', function () {

--- a/tests/Archtech/toCost.php
+++ b/tests/Archtech/toCost.php
@@ -1,6 +1,7 @@
 <?php
 
 use ArchTech\Money\Money;
+
 use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 
 beforeEach(function () {

--- a/tests/Archtech/toCostLessThan.php
+++ b/tests/Archtech/toCostLessThan.php
@@ -1,6 +1,7 @@
 <?php
 
 use ArchTech\Money\Money;
+
 use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 
 beforeEach(function () {

--- a/tests/Archtech/toCostMoreThan.php
+++ b/tests/Archtech/toCostMoreThan.php
@@ -1,6 +1,7 @@
 <?php
 
 use ArchTech\Money\Money;
+
 use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 
 beforeEach(function () {

--- a/tests/Concerns/ProvidesGlobalFunctionAccessors.php
+++ b/tests/Concerns/ProvidesGlobalFunctionAccessors.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Lukeraymonddowning\PestPluginMoney\Tests\Concerns;
 
-use function Lukeraymonddowning\PestPluginMoney\useCurrency;
-use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 use Pest\PendingObjects\TestCall;
 use PHPUnit\Framework\TestCase;
+
+use function Lukeraymonddowning\PestPluginMoney\useCurrency;
+use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 
 trait ProvidesGlobalFunctionAccessors
 {

--- a/tests/toCost.php
+++ b/tests/toCost.php
@@ -1,6 +1,7 @@
 <?php
 
 use Brick\Money\Money;
+
 use function Lukeraymonddowning\PestPluginMoney\useMoneyLibrary;
 
 beforeEach(function () {


### PR DESCRIPTION
**Braking change.**

Upgraded Pest related libraries from v1 to v2.

Upgraded phpunit.xml to be compatibel with PhpUnit 10.

Linted files.

NB: Running `composer test:types` outputs a variant of the following warning for all methods returning a `Pest\Expectation`: 

> Method Lukeraymonddowning\PestPluginMoney\Archtech::toBeMoney() should return Pest\Expectation<TValue> but returns Pest\Mixins\Expectation<TValue>

As far as I can see, this was the case in the master branch of this project as well. I am unsure on how to resolve this.